### PR TITLE
Continous integration using TravisCI and README updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: java
+before_cache:
+  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper
+
+branches:
+  only:
+    - master
+

--- a/README.adoc
+++ b/README.adoc
@@ -11,7 +11,7 @@ Add following to `build.gradle`
 [source,groovy]
 ----
 plugins {
-  id "com.github.lkishalmi.gatling" version "0.1.2"
+  id "com.github.lkishalmi.gatling" version "0.2.0"
 }
 ----
 
@@ -83,11 +83,14 @@ The plugin defines the following extension properties in the `gatling` closure
 '-XX:ThreadPriorityPolicy=42',
 '-Xms512M', '-Xmx512M', '-Xmn100M',
 '-XX:+HeapDumpOnOutOfMemoryError',
-'-XX:+AggressiveOpts', '-XX:+OptimizeStringConcat',
+'-XX:+AggressiveOpts',
+'-XX:+OptimizeStringConcat',
 '-XX:+UseFastAccessorMethods',
-'-XX:+UseParNewGC', '-XX:+UseConcMarkSweepGC',
+'-XX:+UseParNewGC',
+'-XX:+UseConcMarkSweepGC',
 '-XX:+CMSParallelRemarkEnabled',
-'-Djava.net.preferIPv4Stack=true', '-Djava.net.preferIPv6Addresses=false']
+'-Djava.net.preferIPv4Stack=true',
+'-Djava.net.preferIPv6Addresses=false']
 ----
 | Additional arguments passed to JVM when executing `Gatling` simulations
 

--- a/README.adoc
+++ b/README.adoc
@@ -2,6 +2,8 @@
 
 image:http://gatling.io/images/gatling-logo.png[Gatling, 100, 90, link="http://gatling.io/"]
 
+*Master branch* image:https://api.travis-ci.org/lkishalmi/gradle-gatling-plugin.svg?branch=master["Build Status", link="https://travis-ci.org/lkishalmi/gradle-gatling-plugin"]
+
 == Installation
 
 Add following to `build.gradle`

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,5 @@
 = Gatling Plugin for Gradle
+:gatlingToolVersion: 2.1.7
 
 image:http://gatling.io/images/gatling-logo.png[Gatling, 100, 90, link="http://gatling.io/"]
 
@@ -73,7 +74,7 @@ The plugin defines the following extension properties in the `gatling` closure
 [cols="1,1,4a,1a", options="header"]
 |===
 |Property name      |Type           |Default value                              |Description
-|toolVersion        |String         |'2.7.1'                                    |`Gatling` version
+|toolVersion        |String         |'{gatlingToolVersion}'                     |`Gatling` version
 
 |jvmArgs
 |List<String>
@@ -105,10 +106,10 @@ The plugin defines the following extension properties in the `gatling` closure
 
 Example::
 +
-[source,groovy]
+[source,groovy,subs="attributes"]
 ----
 gatling {
-    toolVersion = '2.7.1'
+    toolVersion = '{gatlingToolVersion}'
     jvmArgs = [ '-server', '-Xms512M', '-Xmx512M' ]
     simulations = {
         include "**/folder1/*Simu.scala"    <1>


### PR DESCRIPTION
Resolves #11 
Resolves #13 

1. only `master` branch is built. This can be adjusted in `.travis.yml` if needed
1. build status is displayed in `README`
1. `Gatling` version is fixed in `README`
1. need to setup `TravisCI` hooks after PR approval to allow building of this repository

BTW I've created PR for `Gatling` project to update their docs to point to this plugin as recommended third-party `Gradle` integration tool. Here is [PR](https://github.com/gatling/gatling/pull/2957)