### PR TITLE
Safely remove multiple class directory in Gradle 4.0+ (#51)

### DIFF
--- a/src/main/groovy/com/github/lkishalmi/gradle/gatling/GatlingRunTask.groovy
+++ b/src/main/groovy/com/github/lkishalmi/gradle/gatling/GatlingRunTask.groovy
@@ -1,6 +1,8 @@
 package com.github.lkishalmi.gradle.gatling
 
+import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.JavaExec
+import org.gradle.util.GradleVersion
 
 class GatlingRunTask extends JavaExec {
 
@@ -16,8 +18,12 @@ class GatlingRunTask extends JavaExec {
         classpath = project.configurations.gatlingRuntime
 
         args "-m"
-        if (project.sourceSets.gatling.output.hasProperty("classesDirs")) {
-            args "-bf", "${project.sourceSets.gatling.output.classesDirs[1]}" //TODO remove this hacky way of getting single output directory
+        if (GradleVersion.current() >= GradleVersion.version('4.0')) {
+            File scalaClasses = project.sourceSets.gatling.output.classesDirs.filter {
+                it.parentFile.name == 'scala'
+            }.singleFile
+
+            args '-bf', scalaClasses.absolutePath
         } else {
             args "-bf", "${project.sourceSets.gatling.output.classesDir}"
         }

--- a/src/test/groovy/functional/GatlingFuncSpec.groovy
+++ b/src/test/groovy/functional/GatlingFuncSpec.groovy
@@ -31,4 +31,15 @@ abstract class GatlingFuncSpec extends GatlingSpec {
             .withDebug(true)
             .build()
     }
+
+    BuildResult executeGradle(String task,String gradleVersion) {
+        GradleRunner.create().forwardOutput()
+            .withProjectDir(testProjectDir.getRoot())
+            .withPluginClasspath(pluginClasspath)
+            .withArguments("--stacktrace", GATLING_HOST_NAME_SYS_PROP, task)
+            .withDebug(true)
+            .withGradleVersion(gradleVersion)
+            .forwardOutput()
+            .build()
+    }
 }

--- a/src/test/groovy/functional/GradleCompatibilitySpec.groovy
+++ b/src/test/groovy/functional/GradleCompatibilitySpec.groovy
@@ -1,0 +1,29 @@
+package functional
+
+import org.gradle.testkit.runner.BuildResult
+import spock.lang.Unroll
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class GradleCompatibilitySpec extends GatlingFuncSpec {
+
+    @Unroll
+    void 'use #dirType for Gradle version #gradleVersion'() {
+        setup:
+        prepareTest('gradle')
+
+        when:
+        BuildResult result = executeGradle('tasks',gradleVersion)
+
+        then:
+        result.task(":tasks").outcome == SUCCESS
+        !result.output.contains('Gradle now uses separate output directories for each JVM language, but this build assumes a single directory for all classes from a source set. This behaviour has been deprecated and is scheduled to be removed in Gradle 5.0')
+
+        where:
+        gradleVersion | dirType
+        '3.5'         | 'classesDir'
+        '4.0'         | 'classesDirs'
+        '4.3'         | 'classesDirs'
+
+    }
+}


### PR DESCRIPTION
Removes current hack, which is highly project and operating system dependent.
Original solution relied on project only containing a 'scala' plugin. Once
the project adds for JVM langiage plugins, it failed.

This fix takes the Gradle version into account and switches to use classesDirs
when the version is 4.0 or newer. It find all of the output directories and then
returns only the one that has a parent folder called 'scala'. This work on the
assumption that Gatling tests are only written in Scala. If a Gatlign source set relies
on additional Java|Groovy|Kotlin classes in the same source set, this will still fail.
The chances of someone doing this is probably very low.

Resolves #51