### PR TITLE
Properly pass ENV vars, jvmArgs and system properties to gatling tool

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -45,7 +45,7 @@ Using `Gradle` API file locations can be customized.
 ----
 sourceSets {
   gatling {
-    scala.srcDir "folde1" <1>
+    scala.srcDir "folder1" <1>
     scala.srcDirs = ["folder1"] <2>
 
     resources.srcDir "folder2" <3>
@@ -71,6 +71,7 @@ The plugin defines the following extension properties in the `gatling` closure
 |includeMainOutput  |Boolean        |true                                       |Include main source set output to gatlingCompile
 |includeTestOutput  |Boolean        |true                                       |Include test source set output to gatlingCompile
 |scalaVersion       |String         |'{scalaVersion}'                           |`scala` version that fits your `Gatling` tool version
+
 |jvmArgs
 |List<String>
 |[source,groovy]
@@ -83,11 +84,18 @@ The plugin defines the following extension properties in the `gatling` closure
 '-XX:+PerfDisableSharedMem',
 '-XX:+AggressiveOpts',
 '-XX:+OptimizeStringConcat',
-'-XX:+HeapDumpOnOutOfMemoryError',
-'-Djava.net.preferIPv4Stack=true',
-'-Djava.net.preferIPv6Addresses=false']
+'-XX:+HeapDumpOnOutOfMemoryError']
 ----
-| Additional arguments passed to JVM when executing `Gatling` simulations
+|Additional arguments passed to JVM when executing `Gatling` simulations
+
+|systemProperties
+|Map<String, Object>
+|[source,groovy]
+----
+['java.net.preferIPv4Stack': true,
+'java.net.preferIPv6Addresses': false]
+----
+|Additional systems properties passed to JVM together with caller JVM system properties
 
 |simulations
 |Closure or Iterable<String>
@@ -171,7 +179,7 @@ by default plugin will implicitly use following configuration.
 
 == Dependency management
 
-This plugin defines three configurations `gatling`, `gatlingCompile` and `gatlingRuntime`.
+This plugin defines three https://docs.gradle.org/current/dsl/org.gradle.api.artifacts.Configuration.html[Gradle configurations] `gatling`, `gatlingCompile` and `gatlingRuntime`.
 By default plugin adds `Gatling` libraries to `gatling` configuration.
 Configurations `gatlingCompile` and `gatlingRuntime` extend `gatling`, i.e. all dependencies declared in `gatling` will be inherited.
 
@@ -208,17 +216,38 @@ dependencies {
 
 == Tasks
 
-Plugin provides dedicated task `GatlingRunTask` that is responsible for execute gatling simulations.
-Customer may create instances of this task to execute particular simulations.
-Task extends `Gradle` 's `JavaExec` task.
+Plugin provides `GatlingRunTask` that is responsible for executing `Gatling` simulations.
+Users may create own instances of this task to run particular simulations.
+
+Following configuration options are available. Those options are similar to global `gatling` configurations.
+Options are used in a fallback manner, i.e. if option is not set the value from `gatling` global config is taken.
+
+[cols="1,1,1,2", options="header"]
+|===
+|Property name      |Type           |Default value                              |Description
+
+|jvmArgs
+|List<String>
+|null
+|Additional arguments passed to JVM when executing `Gatling` simulations
+
+|systemProperties
+|Map<String, Object>
+|null
+|Additional systems properties passed to JVM together with caller JVM system properties
+
+|simulations
+|Closure or Iterable<String>
+|null
+|Simulations filter. +
+If closure then https://docs.gradle.org/current/userguide/working_with_files.html[See Gradle docs] for details,
+otherwise an Iterable of simulations fully qualified names.
+|===
 
 === Default tasks
 
-Additionally plugin creates several default tasks
-
 [options="header"]
 |===
-
 |Task name |Type |Description
 
 |`gatlingClasses`

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     exclude module: 'groovy-all'
   }
   testImplementation 'commons-io:commons-io:2.5'
+  testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'
 }
 
 test {

--- a/src/main/groovy/com/github/lkishalmi/gradle/gatling/GatlingPluginExtension.groovy
+++ b/src/main/groovy/com/github/lkishalmi/gradle/gatling/GatlingPluginExtension.groovy
@@ -7,17 +7,20 @@ import java.nio.file.Paths
 
 class GatlingPluginExtension {
 
+    static final String GATLING_MAIN_CLASS = 'io.gatling.app.Gatling'
+
     static final String SIMULATIONS_DIR = "src/gatling/simulations"
 
     static final String RESOURCES_DIR = "src/gatling/resources"
 
-    def toolVersion = '3.2.1'
+    static final String GATLING_TOOL_VERSION = '3.2.1'
 
-    def scalaVersion = '2.12.8'
+    static final String SCALA_VERSION = '2.12.8'
 
-    def jvmArgs = [
+    static final List<String> DEFAULT_JVM_ARGS = [
         '-server',
         '-Xmx1G',
+        '-XX:+HeapDumpOnOutOfMemoryError',
         '-XX:+UseG1GC',
         '-XX:MaxGCPauseMillis=30',
         '-XX:G1HeapRegionSize=16m',
@@ -25,15 +28,24 @@ class GatlingPluginExtension {
         '-XX:+ParallelRefProcEnabled',
         '-XX:+PerfDisableSharedMem',
         '-XX:+AggressiveOpts',
-        '-XX:+OptimizeStringConcat',
-        '-XX:+HeapDumpOnOutOfMemoryError',
-        '-Djava.net.preferIPv4Stack=true',
-        '-Djava.net.preferIPv6Addresses=false'
+        '-XX:+OptimizeStringConcat'
     ]
 
-    def simulations = {
+    static final Map DEFAULT_SYSTEM_PROPS = ["java.net.preferIPv4Stack": true, "java.net.preferIPv6Addresses": false]
+
+    static final Closure DEFAULT_SIMULATIONS = {
         include "**/*Simulation*.scala"
     }
+
+    def toolVersion = GATLING_TOOL_VERSION
+
+    def scalaVersion = SCALA_VERSION
+
+    def jvmArgs = DEFAULT_JVM_ARGS
+
+    def systemProperties = DEFAULT_SYSTEM_PROPS
+
+    def simulations = DEFAULT_SIMULATIONS
 
     def includeMainOutput = true
     def includeTestOutput = true
@@ -46,7 +58,7 @@ class GatlingPluginExtension {
         this.project = project
     }
 
-    Iterable<String> resolveSimulations(Closure simulationFilter = getSimulations()) {
+    Iterable<String> resolveSimulations(Closure simulationFilter) {
         def scalaDirs = project.sourceSets.gatling.scala.srcDirs.collect { Paths.get(it.absolutePath) }
         def scalaFiles = project.sourceSets.gatling.scala.matching(simulationFilter).collect { Paths.get(it.absolutePath) }
 

--- a/src/main/groovy/com/github/lkishalmi/gradle/gatling/GatlingRunTask.groovy
+++ b/src/main/groovy/com/github/lkishalmi/gradle/gatling/GatlingRunTask.groovy
@@ -48,7 +48,11 @@ class GatlingRunTask extends DefaultTask {
                 scalaDirs.find { simu.startsWith(it) }.relativize(simu).join(".") - ".scala"
             }
         } else if (simulationFilter != null && simulationFilter instanceof Iterable<String>) {
-            retval = simulationFilter
+            def scalaDirs = project.sourceSets.gatling.scala.srcDirs
+            retval = simulationFilter.findAll { simuClz ->
+                def file = simuClz.replaceAll("\\.", "/")
+                scalaDirs.any { new File(it, "${file}.scala").exists() }
+            }
         } else {
             throw new IllegalArgumentException("`simulations` property neither Closure nor Iterable<String>, simulations: $simulationFilter")
         }

--- a/src/test/groovy/functional/WhenCompileSimulationSpec.groovy
+++ b/src/test/groovy/functional/WhenCompileSimulationSpec.groovy
@@ -52,12 +52,8 @@ class WhenCompileSimulationSpec extends GatlingFuncSpec {
     def "should not compile without required dependencies"() {
         given:
         new File(testProjectDir.root, "build.gradle").text = """
-plugins {
-    id 'com.github.lkishalmi.gatling'
-}
-repositories {
-    jcenter()
-}
+plugins { id 'com.github.lkishalmi.gatling' }
+repositories { jcenter() }
 """
         when:
         executeGradle(GATLING_CLASSES_TASK_NAME)

--- a/src/test/groovy/functional/WhenRunSimulationSpec.groovy
+++ b/src/test/groovy/functional/WhenRunSimulationSpec.groovy
@@ -2,8 +2,6 @@ package functional
 
 import helper.GatlingFuncSpec
 import org.gradle.testkit.runner.BuildResult
-import spock.lang.Ignore
-import spock.lang.Unroll
 
 import static com.github.lkishalmi.gradle.gatling.GatlingPlugin.GATLING_RUN_TASK_NAME
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
@@ -63,7 +61,7 @@ gatling.charting.noReports = true
 
     def "should not fail when layout is incorrect"() {
         setup:
-        prepareTest(false)
+        prepareTest(null)
         when:
         BuildResult result = executeGradle(GATLING_RUN_TASK_NAME)
         then: "default tasks were executed successfully"

--- a/src/test/groovy/functional/WhenRunSimulationSysPropsJvmArgsSpec.groovy
+++ b/src/test/groovy/functional/WhenRunSimulationSysPropsJvmArgsSpec.groovy
@@ -1,0 +1,157 @@
+package functional
+
+import com.github.lkishalmi.gradle.gatling.GatlingPluginExtension
+import helper.GatlingDebug
+import helper.GatlingFuncSpec
+import org.gradle.testkit.runner.BuildResult
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.EnvironmentVariables
+import org.junit.contrib.java.lang.system.RestoreSystemProperties
+
+import static com.github.lkishalmi.gradle.gatling.GatlingPlugin.GATLING_RUN_TASK_NAME
+
+class WhenRunSimulationSysPropsJvmArgsSpec extends GatlingFuncSpec {
+
+    @Rule
+    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties()
+
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
+
+    def setup() {
+        prepareTest("/gatling-debug")
+        new File(new File(testProjectDir.root, "src/gatling/resources"), "gatling.conf").text = "gatling.data.writers = []"
+    }
+
+    def "should set memory limits from jvmArgs of gatling extension"() {
+        when: "default Xmx from gatling extension"
+        BuildResult result = executeGradle(GATLING_RUN_TASK_NAME)
+        then:
+        with(new GatlingDebug(result)) {
+            heap.max == 1024 * 1024 * 1024// 1GB
+        }
+
+        when: "override via gatling extension"
+        buildFile << """
+gatling {
+    jvmArgs = ['-Xms32m']
+}    
+"""
+        and:
+        result = executeGradle(GATLING_RUN_TASK_NAME)
+        then:
+        with(new GatlingDebug(result)) {
+            heap.min == 32 * 1024 * 1024
+        }
+    }
+
+    def "should configure jvmArgs from extension"() {
+        when: "default jvmArgs from gatling extension"
+        BuildResult result = executeGradle(GATLING_RUN_TASK_NAME)
+        then:
+        with(new GatlingDebug(result)) {
+            jvmArgs.sort() == GatlingPluginExtension.DEFAULT_JVM_ARGS.findAll { it.startsWith("-X") }.sort()
+        }
+
+        when: "override via gatling extension"
+        buildFile << """
+gatling {
+    jvmArgs = ['-Xms32m', '-XX:+UseG1GC']
+}
+"""
+        and:
+        result = executeGradle(GATLING_RUN_TASK_NAME)
+        then:
+        with(new GatlingDebug(result)) {
+            jvmArgs.sort() == ['-Xms32m', '-XX:+UseG1GC'].sort()
+        }
+    }
+
+    def "should override jvmArgs from gatlingRun properties"() {
+        when: "override via gatlingRun"
+        buildFile << """
+gatling {
+    jvmArgs = ['-Xms32m', '-XX:+AggressiveOpts']
+}
+gatlingRun {
+    jvmArgs = ['-Xms128m', '-XX:+UseG1GC']
+}
+"""
+        and:
+        def result = executeGradle(GATLING_RUN_TASK_NAME)
+        then:
+        with(new GatlingDebug(result)) {
+            jvmArgs.sort() == ['-Xms128m', '-XX:+UseG1GC'].sort()
+        }
+    }
+
+    def "should configure system properties from extension"() {
+        when: "defalts from extension"
+        def result = executeGradle(GATLING_RUN_TASK_NAME)
+        then:
+        with(new GatlingDebug(result)) {
+            systemProperties.keySet().intersect(GatlingPluginExtension.DEFAULT_SYSTEM_PROPS.keySet()).size() == GatlingPluginExtension.DEFAULT_SYSTEM_PROPS.size()
+        }
+
+        when: "override via extension"
+        buildFile << """
+gatling {
+    systemProperties = ['gradle_gatling_1': 'aaa', 'gradle_gatling_2' : 'bbb']
+}
+"""
+        and:
+        result = executeGradle(GATLING_RUN_TASK_NAME)
+        then:
+        with(new GatlingDebug(result)) {
+            systemProperties.keySet().findAll { it.startsWith("gradle_gatling_") } == ['gradle_gatling_1', 'gradle_gatling_2'] as Set
+            systemProperties["gradle_gatling_1"] == "aaa"
+            systemProperties["gradle_gatling_2"] == "bbb"
+
+            systemProperties.keySet().intersect(GatlingPluginExtension.DEFAULT_SYSTEM_PROPS.keySet()).size() == 0
+        }
+    }
+
+    def "should extend system properties from extension"() {
+    }
+
+    def "should extend system properties from gatlingRun properties"() {
+        given: "override via gatlingRun"
+        buildFile << """
+gatling {
+    systemProperties = ['gradle_gatling_1': 'aaa', 'gradle_gatling_2' : 'bbb']
+}
+gatlingRun {
+    systemProperties = ['gradle_gatling_2' : 'qwerty', 'gradle_gatling_3' : 'ccc']    
+}
+"""
+        when:
+        def result = executeGradle(GATLING_RUN_TASK_NAME)
+        then:
+        with(new GatlingDebug(result)) {
+            systemProperties.keySet().findAll { it.startsWith("gradle_gatling_") } == ['gradle_gatling_2', 'gradle_gatling_3'] as Set
+            systemProperties["gradle_gatling_2"] == "qwerty"
+        }
+    }
+
+    def "should pass env vars upstream"() {
+        given:
+        environmentVariables.set("GRADLE_GATLING_ENV_UPSTREAM", "env_upstream_value")
+        when:
+        def result = executeGradle(GATLING_RUN_TASK_NAME)
+        then:
+        with(new GatlingDebug(result)) {
+            env["GRADLE_GATLING_ENV_UPSTREAM"] == "env_upstream_value"
+        }
+    }
+
+    def "should pass system properties upstream"() {
+        given:
+        System.setProperty("gradle_gatling_sys_upstream", "sys_upstream_value")
+        when:
+        def result = executeGradle(GATLING_RUN_TASK_NAME)
+        then:
+        with(new GatlingDebug(result)) {
+            systemProperties["gradle_gatling_sys_upstream"] == "sys_upstream_value"
+        }
+    }
+}

--- a/src/test/groovy/helper/GatlingDebug.groovy
+++ b/src/test/groovy/helper/GatlingDebug.groovy
@@ -1,0 +1,33 @@
+package helper
+
+import com.github.lkishalmi.gradle.gatling.GatlingPlugin
+import groovy.json.JsonSlurper
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.TaskOutcome
+
+class GatlingDebug {
+
+    Map systemProperties
+    Map env
+
+    List<String> jvmArgs
+    List<String> argv
+
+    Map heap
+
+    GatlingDebug(BuildResult buildResult) {
+        assert buildResult.task(":$GatlingPlugin.GATLING_RUN_TASK_NAME").outcome == TaskOutcome.SUCCESS
+
+        def lines = buildResult.output.readLines().findAll { it.startsWith("@@@@") }
+        assert lines.size() == 4
+
+        def jsonSlurper = new JsonSlurper()
+
+        this.heap = jsonSlurper.parseText(lines.find { it.startsWith("@@@@.heap") } - "@@@@.heap ")
+        this.jvmArgs = jsonSlurper.parseText(lines.find { it.startsWith("@@@@.jvm") } - "@@@@.jvm ")
+        this.systemProperties = jsonSlurper.parseText((lines.find { it.startsWith("@@@@.sys") } - "@@@@.sys "))
+        this.env = jsonSlurper.parseText((lines.find { it.startsWith("@@@@.env") } - "@@@@.env "))
+
+        this.argv = this.systemProperties["sun.java.command"].split("\\s") as List
+    }
+}

--- a/src/test/groovy/helper/GatlingFuncSpec.groovy
+++ b/src/test/groovy/helper/GatlingFuncSpec.groovy
@@ -7,8 +7,8 @@ abstract class GatlingFuncSpec extends GatlingSpec {
 
     static def GATLING_HOST_NAME_SYS_PROP = "-Dgatling.hostName=HTTP://COMPUTER-DATABASE.GATLING.IO"
 
-    File prepareTest(boolean copyFiles = true) {
-        createBuildFolder(copyFiles)
+    File prepareTest(String fixtureDir = "/gradle-layout") {
+        createBuildFolder(fixtureDir)
         generateBuildScripts()
     }
 

--- a/src/test/groovy/helper/GatlingFuncSpec.groovy
+++ b/src/test/groovy/helper/GatlingFuncSpec.groovy
@@ -7,7 +7,7 @@ abstract class GatlingFuncSpec extends GatlingSpec {
 
     static def GATLING_HOST_NAME_SYS_PROP = "-Dgatling.hostName=HTTP://COMPUTER-DATABASE.GATLING.IO"
 
-    File prepareTest(String fixtureDir = "/gradle-layout") {
+    void prepareTest(String fixtureDir = "/gradle-layout") {
         createBuildFolder(fixtureDir)
         generateBuildScripts()
     }
@@ -28,7 +28,6 @@ abstract class GatlingFuncSpec extends GatlingSpec {
             .withPluginClasspath()
             .withDebug(true)
             .withGradleVersion(gradleVersion)
-            .forwardOutput()
             .build()
     }
 }

--- a/src/test/groovy/helper/GatlingSpec.groovy
+++ b/src/test/groovy/helper/GatlingSpec.groovy
@@ -2,7 +2,6 @@ package helper
 
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
-import spock.lang.Shared
 import spock.lang.Specification
 
 import static org.apache.commons.io.FileUtils.copyDirectory
@@ -13,9 +12,9 @@ abstract class GatlingSpec extends Specification {
 
     File testProjectBuildDir
 
-    def createBuildFolder(boolean copyFiles = true) {
-        if (copyFiles) {
-            copyDirectory(new File(this.class.getResource("/gradle-layout").file), testProjectDir.root)
+    def createBuildFolder(String fixtureDir) {
+        if (fixtureDir) {
+            copyDirectory(new File(this.class.getResource(fixtureDir).file), testProjectDir.root)
         }
         testProjectBuildDir = new File(testProjectDir.root, "build")
     }

--- a/src/test/groovy/helper/GatlingSpec.groovy
+++ b/src/test/groovy/helper/GatlingSpec.groovy
@@ -12,6 +12,8 @@ abstract class GatlingSpec extends Specification {
 
     File testProjectBuildDir
 
+    File buildFile
+
     def createBuildFolder(String fixtureDir) {
         if (fixtureDir) {
             copyDirectory(new File(this.class.getResource(fixtureDir).file), testProjectDir.root)
@@ -20,7 +22,8 @@ abstract class GatlingSpec extends Specification {
     }
 
     def generateBuildScripts() {
-        testProjectDir.newFile("build.gradle") << """
+        buildFile = testProjectDir.newFile("build.gradle")
+        buildFile.text = """
 plugins {
     id 'com.github.lkishalmi.gatling'
 }

--- a/src/test/groovy/helper/GatlingUnitSpec.groovy
+++ b/src/test/groovy/helper/GatlingUnitSpec.groovy
@@ -15,7 +15,7 @@ abstract class GatlingUnitSpec extends GatlingSpec {
     GatlingRunTask gatlingRunTask
 
     def setup() {
-        createBuildFolder()
+        createBuildFolder("/gradle-layout")
 
         project = ProjectBuilder.builder().withProjectDir(testProjectDir.root).build()
         project.pluginManager.apply 'com.github.lkishalmi.gatling'

--- a/src/test/groovy/unit/GatlingPluginTest.groovy
+++ b/src/test/groovy/unit/GatlingPluginTest.groovy
@@ -14,13 +14,26 @@ class GatlingPluginTest extends GatlingUnitSpec {
         }
     }
 
-    def "should add gatling dependencies"() {
+    def "should create gatling extension for project "() {
+        expect:
+        with(gatlingExt) {
+            it instanceof GatlingPluginExtension
+            it.simulations == GatlingPluginExtension.DEFAULT_SIMULATIONS
+            it.jvmArgs == GatlingPluginExtension.DEFAULT_JVM_ARGS
+            it.systemProperties == GatlingPluginExtension.DEFAULT_SYSTEM_PROPS
+            it.logLevel == "WARN"
+        }
+    }
+
+    def "should add gatling dependencies with default version"() {
         when:
         project.evaluate()
         then:
-        def gatlingExt = project.extensions.findByType(GatlingPluginExtension)
         project.configurations.getByName("gatling").allDependencies.find {
-            it.name == "gatling-charts-highcharts" && it.version == gatlingExt.toolVersion
+            it.name == "gatling-charts-highcharts" && it.version ==GatlingPluginExtension.GATLING_TOOL_VERSION
+        }
+        project.configurations.getByName("gatlingCompile").allDependencies.find {
+            it.name == "scala-library" && it.version == GatlingPluginExtension.SCALA_VERSION
         }
     }
 
@@ -40,7 +53,6 @@ class GatlingPluginTest extends GatlingUnitSpec {
         project.gatling { scalaVersion = '2.11.3' }
         and:
         project.evaluate()
-
         then:
         project.configurations.getByName("gatlingCompile").allDependencies.find {
             it.name == "scala-library" && it.version == "2.11.3"
@@ -51,15 +63,17 @@ class GatlingPluginTest extends GatlingUnitSpec {
         expect:
         with(gatlingRunTask) {
             it instanceof GatlingRunTask
-            it.simulations == gatlingExt.simulations
-            it.jvmArgs == gatlingExt.jvmArgs
+            it.simulations == null
+            it.jvmArgs == null
+            it.systemProperties == null
         }
     }
 
     def "should create processGatlingResources task"() {
         expect:
-        project.tasks.getByName("processGatlingResources") != null
-        and:
-        project.tasks.getByName("processGatlingResources").actions.find { it.action instanceof LogbackConfigTaskAction }
+        with(project.tasks.getByName("processGatlingResources")) {
+            it != null
+            it.actions.find { it.action instanceof LogbackConfigTaskAction } != null
+        }
     }
 }

--- a/src/test/groovy/unit/GatlingRunTaskTest.groovy
+++ b/src/test/groovy/unit/GatlingRunTaskTest.groovy
@@ -86,9 +86,7 @@ class GatlingRunTaskTest extends GatlingUnitSpec {
 
         when: 'fake source dirs without simulations'
         project.sourceSets {
-            gatling {
-                scala.srcDirs = [overridenSrc]
-            }
+            gatling.scala.srcDirs = [overridenSrc]
         }
         then:
         gatlingRunTask.resolveSimulations().size() == 0
@@ -106,9 +104,7 @@ class GatlingRunTaskTest extends GatlingUnitSpec {
 
         when: 'fake source dirs without simulations'
         project.sourceSets {
-            gatling {
-                scala.srcDir overridenSrc
-            }
+            gatling.scala.srcDir overridenSrc
         }
         then:
         gatlingRunTask.resolveSimulations().size() == 2
@@ -126,10 +122,22 @@ class GatlingRunTaskTest extends GatlingUnitSpec {
     }
 
     def "should fail if extension static list is not in sourceSet"() {
-
+        when: 'fake source dirs without simulations and static list'
+        project.sourceSets {
+            gatling.scala.srcDirs = ["test/gatling/scala"]
+        }
+        project.gatling { simulations = ["computerdatabase.BasicSimulation"] }
+        then:
+        gatlingRunTask.resolveSimulations().size() == 0
     }
 
     def "should fail if gatlingRun static list is not in sourceSet"() {
-
+        when: 'fake source dirs without simulations and static list'
+        project.sourceSets {
+            gatling.scala.srcDirs = ["test/gatling/scala"]
+        }
+        project.gatlingRun { simulations = ["computerdatabase.BasicSimulation"] }
+        then:
+        gatlingRunTask.resolveSimulations().size() == 0
     }
 }

--- a/src/test/resources/gatling-debug/src/gatling/simulations/GatlingDebugSimulation.scala
+++ b/src/test/resources/gatling-debug/src/gatling/simulations/GatlingDebugSimulation.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2011-2018 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+import scala.collection.JavaConverters._
+import java.lang.management.ManagementFactory
+import java.lang.management.RuntimeMXBean
+import java.util
+
+class GatlingDebugSimulation extends Simulation {
+
+  import org.json4s._
+  import org.json4s.jackson.JsonMethods._
+  import org.json4s.jackson.Serialization
+  import org.json4s.jackson.Serialization._
+
+  implicit val formats = DefaultFormats
+
+  private val heapMemory = ManagementFactory.getMemoryMXBean.getHeapMemoryUsage
+
+  println(s"""@@@@.heap {"min": ${heapMemory.getInit}, "max": ${heapMemory.getMax}}""")
+
+  private val jvmArgs  = ManagementFactory.getRuntimeMXBean.getInputArguments
+
+  println(s"@@@@.jvm ${write(jvmArgs.asScala.filterNot(_.startsWith("-D")))}}")
+
+  println(s"@@@@.env ${write(System.getenv.asScala)}}")
+
+  println(s"@@@@.sys ${write(System.getProperties.asScala)}}")
+
+  setUp(scenario("Scenario Name").pause(1).inject(atOnceUsers(0)))
+}


### PR DESCRIPTION
The issue required huge refactoring

- `GatlingRunTask` doesn't extends JavaExec, but exposes own `jvmArgs` and `systemProperties` instead
- all convention mappings are removed since `Gradle` doesn't recommend its usage
- instances of `GatlingRunTask` having empty parameters and fall back to ones declated in `gatling` extension
- Dedicated tool developed to access parameters of forked JVM where gatling is run
- Functional tests added to cover all the cases


Resolves #33 